### PR TITLE
use separate namespace format toggles for perspectives and imc

### DIFF
--- a/conf/config.js
+++ b/conf/config.js
@@ -44,12 +44,18 @@ config.pubSubPerspectives =
 
 const toggles = {
   // use old socket.io namespace format
-  useOldNamespaceFormat: environmentVariableTrue(pe, 'USE_OLD_NAMESPACE_FORMAT'),
+  useOldNamespaceFormatPersp: environmentVariableTrue(pe, 'USE_OLD_NAMESPACE_FORMAT_PERSPECTIVES'),
+
+  // use old socket.io namespace format for IMC
+  useOldNamespaceFormatImc: environmentVariableTrue(pe, 'USE_OLD_NAMESPACE_FORMAT_IMC'),
 
   // use new socket.io namespace/room format
   useNewNamespaceFormat: environmentVariableTrue(pe, 'USE_NEW_NAMESPACE_FORMAT'),
 
-  // use new socket.io namespace/room format
+  // use new socket.io namespace/room format for IMC
+  useNewNamespaceFormatImc: environmentVariableTrue(pe, 'USE_NEW_NAMESPACE_FORMAT_IMC'),
+
+  // enable logging pubsub stats
   enablePubSubStatsLogs: environmentVariableTrue(pe, 'ENABLE_PUBSUB_STATS_LOGS'),
 }; // shortTermToggles
 

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -23,10 +23,10 @@ const initEvent = {
 module.exports = (io, key, obj, pubOpts) => {
   // newObjectAsString contains { key: {new: obj }}
   const newObjectAsString = u.getNewObjAsString(key, obj);
+  const eventType = key.split('.')[eventTypeIndex];
 
   // NEW
   if (toggle.isFeatureEnabled('useNewNamespaceFormat')) {
-    const eventType = key.split('.')[eventTypeIndex];
     if (eventType === 'subject' || eventType === 'sample') {
       const perspectives = Array.from(u.connectedRooms['/perspectives']).filter((roomName) =>
         u.shouldIEmitThisObj(roomName, obj)
@@ -46,14 +46,29 @@ module.exports = (io, key, obj, pubOpts) => {
   }
 
   // OLD
-  if (toggle.isFeatureEnabled('useOldNamespaceFormat')) {
-    // Initialize namespace if init event is sent for perspective or bot
+  // Initialize namespace if init event is sent for perspective
+  if (toggle.isFeatureEnabled('useOldNamespaceFormatPersp')) {
     if (key.startsWith(initEvent.perspective)) {
       u.initializePerspectiveNamespace(obj, io);
-    } else if (key.startsWith(initEvent.bot)) {
+    }
+  }
+
+  // OLD
+  // Initialize namespace if init event is sent for bot
+  if (toggle.isFeatureEnabled('useOldNamespaceFormatImc')) {
+    if (key.startsWith(initEvent.bot)) {
       u.initializeBotNamespace(obj, io);
     }
+  }
 
+  // OLD
+  let emitPersp = toggle.isFeatureEnabled('useOldNamespaceFormatPersp')
+                  && (eventType === 'subject' || eventType === 'sample');
+
+  let emitImc = toggle.isFeatureEnabled('useOldNamespaceFormatImc')
+                && (eventType === 'bot' || eventType === 'room');
+
+  if (emitPersp || emitImc) {
     /*
      * Socket.io does not expose any API to retrieve list of all the namespaces
      * which have been initialized. We use `Object.keys(io.nsps)` here, which

--- a/src/namespaceInit.js
+++ b/src/namespaceInit.js
@@ -28,24 +28,10 @@ module.exports = (io) => {
   }
 
   // OLD
-  if (toggle.isFeatureEnabled('useOldNamespaceFormat')) {
-    return Promise.join(
-      req
-        .get(`${conf.apiUrl}/v1/perspectives`)
-        .set('Authorization', conf.apiToken),
-      req
-        .get(`${conf.apiUrl}/v1/rooms?active=true`)
-        .set('Authorization', conf.apiToken),
-    )
-    .then(([perspectivesResponse, roomsResponse]) => {
-      perspectivesResponse.body.forEach((p) =>
-        utils.initializePerspectiveNamespace(p, io)
-      );
-      roomsResponse.body.forEach((r) =>
-        utils.initializeBotNamespace(r, io)
-      );
-    });
-  }
-
-  return Promise.resolve();
+  const useOldFormatPersp= toggle.isFeatureEnabled('useOldNamespaceFormatPersp');
+  const useOldFormatImc = toggle.isFeatureEnabled('useOldNamespaceFormatImc');
+  return Promise.join(
+    useOldFormatPersp && utils.initializePerspectiveNamespacesFromApi(io),
+    useOldFormatImc && utils.initializeBotNamespacesFromApi(io),
+  );
 };

--- a/test/clientConnect.js
+++ b/test/clientConnect.js
@@ -73,7 +73,8 @@ describe('test/clientConnect.js >', () => {
     let client;
 
     beforeEach(() => {
-      testUtil.toggleOverride('useOldNamespaceFormat', true);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', true);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', true);
       testUtil.toggleOverride('useNewNamespaceFormat', false);
       sioServer = require('socket.io')(3000);
 
@@ -83,7 +84,8 @@ describe('test/clientConnect.js >', () => {
     });
 
     afterEach((done) => {
-      testUtil.toggleOverride('useOldNamespaceFormat', false);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', false);
       testUtil.toggleOverride('useNewNamespaceFormat', false);
       client && client.close();
       sioServer.close(done);
@@ -246,7 +248,8 @@ describe('test/clientConnect.js >', () => {
     let client;
 
     beforeEach(() => {
-      testUtil.toggleOverride('useOldNamespaceFormat', false);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', false);
       testUtil.toggleOverride('useNewNamespaceFormat', true);
       sioServer = require('socket.io')(3000);
       utils.initializeNamespace('/bots', sioServer);
@@ -255,7 +258,8 @@ describe('test/clientConnect.js >', () => {
     });
 
     afterEach((done) => {
-      testUtil.toggleOverride('useOldNamespaceFormat', false);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', false);
       testUtil.toggleOverride('useNewNamespaceFormat', false);
       client && client.close();
       sioServer.close(done);

--- a/test/socketIOEmitter.js
+++ b/test/socketIOEmitter.js
@@ -196,7 +196,8 @@ describe('test/socketIOEmitter.js >', () => {
       let connectedClients;
 
       before(() => {
-        testUtil.toggleOverride('useOldNamespaceFormat', true);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', true);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', true);
         testUtil.toggleOverride('useNewNamespaceFormat', false);
         sioServer = require('socket.io')(3000);
 
@@ -229,7 +230,8 @@ describe('test/socketIOEmitter.js >', () => {
       });
 
       after((done) => {
-        testUtil.toggleOverride('useOldNamespaceFormat', false);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', false);
         testUtil.toggleOverride('useNewNamespaceFormat', false);
         connectUtil.closeClients(connectedClients);
         sioServer.close(done);
@@ -243,7 +245,8 @@ describe('test/socketIOEmitter.js >', () => {
       let connectedClients;
 
       before(() => {
-        testUtil.toggleOverride('useOldNamespaceFormat', false);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', false);
         testUtil.toggleOverride('useNewNamespaceFormat', true);
         sioServer = require('socket.io')(3000);
         utils.initializeNamespace('/bots', sioServer);
@@ -267,7 +270,8 @@ describe('test/socketIOEmitter.js >', () => {
       });
 
       after((done) => {
-        testUtil.toggleOverride('useOldNamespaceFormat', false);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', false);
         testUtil.toggleOverride('useNewNamespaceFormat', false);
         connectUtil.closeClients(connectedClients);
         sioServer.close(done);
@@ -281,7 +285,8 @@ describe('test/socketIOEmitter.js >', () => {
       let connectedClients;
 
       before(() => {
-        testUtil.toggleOverride('useOldNamespaceFormat', true);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', true);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', true);
         testUtil.toggleOverride('useNewNamespaceFormat', true);
         sioServer = require('socket.io')(3000);
 
@@ -329,7 +334,8 @@ describe('test/socketIOEmitter.js >', () => {
       });
 
       after((done) => {
-        testUtil.toggleOverride('useOldNamespaceFormat', false);
+        testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+        testUtil.toggleOverride('useOldNamespaceFormatImc', false);
         testUtil.toggleOverride('useNewNamespaceFormat', false);
         connectUtil.closeClients(connectedClients);
         sioServer.close(done);
@@ -2178,14 +2184,16 @@ describe('test/socketIOEmitter.js >', () => {
     let sioServer;
     let clients;
     beforeEach(() => {
-      testUtil.toggleOverride('useOldNamespaceFormat', false);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', false);
       testUtil.toggleOverride('useNewNamespaceFormat', true);
       sioServer = require('socket.io')(3000);
       utils.initializeNamespace('/perspectives', sioServer);
     });
 
     afterEach((done) => {
-      testUtil.toggleOverride('useOldNamespaceFormat', false);
+      testUtil.toggleOverride('useOldNamespaceFormatPersp', false);
+      testUtil.toggleOverride('useOldNamespaceFormatImc', false);
       testUtil.toggleOverride('useNewNamespaceFormat', false);
       clients.forEach((client) => client.close());
       sioServer.close(done);

--- a/util/emitUtils.js
+++ b/util/emitUtils.js
@@ -280,6 +280,40 @@ function initializePerspectiveNamespace(inst, io) {
 
 // OLD - remove along with namespace toggles
 /**
+ * Makes an api call to get all existing perspectives, and initializes
+ * namespaces based on the response.
+ * @param {Socket.io} io - The socketio's server side object
+ */
+function initializePerspectiveNamespacesFromApi(io) {
+  return req
+  .get(`${conf.apiUrl}/v1/perspectives`)
+  .set('Authorization', conf.apiToken)
+  .then((perspectives) =>
+    perspectives.body.forEach((p) =>
+      initializePerspectiveNamespace(p, io)
+    )
+  );
+}
+
+// OLD - remove along with namespace toggles
+/**
+ * Makes an api call to get all existing Imc rooms, and initializes
+ * namespaces based on the response.
+ * @param {Socket.io} io - The socketio's server side object
+ */
+function initializeBotNamespacesFromApi(io) {
+  return req
+  .get(`${conf.apiUrl}/v1/rooms?active=true`)
+  .set('Authorization', conf.apiToken)
+  .then((rooms) =>
+    rooms.body.forEach((r) =>
+      initializeBotNamespace(r, io)
+    )
+  );
+}
+
+// OLD - remove along with namespace toggles
+/**
  * Initializes a socketIO namespace based on the bot object.
  * @param {Object} inst - The perspective instance.
  * @param {Socket.io} io - The socketio's server side object
@@ -492,6 +526,8 @@ module.exports = {
   getPerspectiveNamespaceString,
   initializeBotNamespace,
   initializePerspectiveNamespace,
+  initializePerspectiveNamespacesFromApi,
+  initializeBotNamespacesFromApi,
   initializeNamespace,
   connectedRooms,
   shouldIEmitThisObj,


### PR DESCRIPTION
Adding this functionality so we can go ahead and disable it for both now, then turn it on just for imc when we are ready to move those over to the realtime app.