### PR TITLE
Change emitToClients to allow for multiple bot connections

### DIFF
--- a/src/util/emitUtils.js
+++ b/src/util/emitUtils.js
@@ -553,12 +553,13 @@ function getNewObjAsString(key, obj) {
  * In the case of multiple connections to the same socket.io room
  * (ie. multiple instances of the same bot) this function will emit
  * data to only one.
- * @param {Socket.io} io
- * @param {string} nsp
- * @param {string} room
+ * @param {Socket.io} io - socket.io server
+ * @param {String} nsp - name of namespace
+ * @param {String} room - id of room within namespace
+ * @param {Socket.io} namespace - object representing namespace
  */
-function emitToSingleInstance(io, nsp, room) {
-  const connectionsToRoom = io.nsps[nsp].adapter.rooms[room];
+function emitToSingleInstance(io, namespace, namespaceId, room) {
+  const connectionsToRoom = io.nsps[namespaceId].adapter.rooms[room];
   const connectionToEmitTo = connectionsToRoom && connectionsToRoom.sockets ?
     Object.keys(connectionsToRoom.sockets)[0] : null;
   if (connectionToEmitTo) namespace.to(connectionToEmitTo);
@@ -580,7 +581,7 @@ function emitToClients(io, nsp, rooms, key, obj) {
     doEmitWithTracking(namespace, key, obj, rooms);
   } else if (rooms && rooms.length) {
       if (nsp === '/bots') {
-        rooms.forEach((room) => emitToSingleInstance(io, nsp, room));
+        rooms.forEach((room) => emitToSingleInstance(io, namespace, nsp, room));
         doEmit(namespace, key, obj);
       }  else {
         rooms.forEach((room) => namespace.to(room));

--- a/src/util/emitUtils.js
+++ b/src/util/emitUtils.js
@@ -554,9 +554,9 @@ function getNewObjAsString(key, obj) {
  * (ie. multiple instances of the same bot) this function will emit
  * data to only one.
  * @param {Socket.io} io - socket.io server
- * @param {String} nsp - name of namespace
- * @param {String} room - id of room within namespace
  * @param {Socket.io} namespace - object representing namespace
+ * @param {String} namespaceId - name of namespace
+ * @param {String} room - id of room within namespace
  */
 function emitToSingleInstance(io, namespace, namespaceId, room) {
   const connectionsToRoom = io.nsps[namespaceId].adapter.rooms[room];

--- a/src/util/namespaceModifiers.js
+++ b/src/util/namespaceModifiers.js
@@ -1,0 +1,19 @@
+/**
+ * In the case of multiple instances connected to the same socket.io room
+ * (ie. multiple instances of the same bot) this function will set the namespace
+ *  to only emit data to one.
+ * @param {Socket.io} io - socket.io server
+ * @param {Socket.io} namespace - object representing namespace
+ * @param {String} namespaceId - name of namespace
+ * @param {String} room - id of room within namespace
+ */
+function setNamespaceToEmitToSingleInstance(io, namespace, namespaceId, room) {
+  const connectionsToRoom = io.nsps[namespaceId].adapter.rooms[room];
+  const connectionToEmitTo = connectionsToRoom && connectionsToRoom.sockets ?
+    Object.keys(connectionsToRoom.sockets)[0] : null;
+  if (connectionToEmitTo) namespace.to(connectionToEmitTo);
+}
+
+module.exports =  {
+  setNamespaceToEmitToSingleInstance
+};


### PR DESCRIPTION
Makes an adjustment to the emitToClients function.

If we are emitting the the /bots namespace, the code will grab an array of the connections to the room we are emitting to (e.g all instances connected to the OnCall Bot room) and will then only emit the event to the first connection in the list.

This functionality is only for bots and emitting to IMC rooms and perspectives will remain the same.